### PR TITLE
Disable Git LFS by default

### DIFF
--- a/com.sublimemerge.App.yaml
+++ b/com.sublimemerge.App.yaml
@@ -52,7 +52,6 @@ modules:
         dest-filename: sublime_merge.sh
         commands:
           - export PATH="$PATH:/app/libexec/git-lfs"
-          - /app/libexec/git-lfs/git-lfs install --system >/dev/null
           - exec /app/extra/bin/smerge $@
       - type: extra-data
         only-arches: ["x86_64"]


### PR DESCRIPTION
LFS should not be enabled by default because it causes issues if it is not installed on the host system too.

> This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting .git/hooks/post-checkout.

Sprouts from #4.