### PR TITLE
Fix signing with GPG keys on Fedora

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.flatpak-builder/
+*build*/

--- a/com.sublimemerge.App.yaml
+++ b/com.sublimemerge.App.yaml
@@ -44,8 +44,8 @@ modules:
       - --without-libcap
     sources:
       - type: archive
-        sha256: cd12a064013ed18e2ee8475e669b9f58db1b225a0144debdb85a68cecddba57f
-        url: https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.1.1.tar.bz2
+        sha256: 10072045a3e043d0581f91cd5676fcac7ffee957a16636adedaa4f583a616470
+        url: https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.2.0.tar.bz2
 
   - name: git-lfs
     buildsystem: simple

--- a/com.sublimemerge.App.yaml
+++ b/com.sublimemerge.App.yaml
@@ -15,7 +15,8 @@ finish-args:
   - --share=network
   - --filesystem=host  # uses the SDK's git binary directly, no portals
   - --filesystem=xdg-run/gnupg:ro  # for signing commits
-  - --talk-name=org.freedesktop.secrets # for access to the user's GPG keys for signing commits
+  - --filesystem=xdg-run/keyring # for access to the user's keyring to unlock GPG keys in order to sign commits
+  - --talk-name=org.freedesktop.secrets # for access to the user's keyring to unlock GPG keys in order to sign commits
   - --own-name=com.sublimemerge # app doesn't follow the app ID spec
   - --device=dri
 

--- a/com.sublimemerge.App.yaml
+++ b/com.sublimemerge.App.yaml
@@ -17,10 +17,36 @@ finish-args:
   - --filesystem=xdg-run/gnupg:ro  # for signing commits
   - --filesystem=xdg-run/keyring # for access to the user's keyring to unlock GPG keys in order to sign commits
   - --talk-name=org.freedesktop.secrets # for access to the user's keyring to unlock GPG keys in order to sign commits
+  - --talk-name=org.gnome.keyring.SystemPrompter # allow GNOME Keyring to prompt for passphrase
   - --own-name=com.sublimemerge # app doesn't follow the app ID spec
   - --device=dri
 
 modules:
+  - name: pinentry
+    cleanup:
+      - /include
+      - /lib/debug
+      - /share/info
+      - '*.a'
+      - '*.la'
+    config-opts:
+      - --disable-fallback-curses
+      - --disable-ncurses
+      - --disable-pinentry-curses
+      - --disable-pinentry-emacs
+      - --disable-pinentry-fltk
+      - --disable-pinentry-gtk2
+      - --disable-pinentry-qt5
+      - --disable-pinentry-tqt
+      - --disable-pinentry-tty
+      - --enable-libsecret=no
+      - --enable-pinentry-gnome3
+      - --without-libcap
+    sources:
+      - type: archive
+        sha256: cd12a064013ed18e2ee8475e669b9f58db1b225a0144debdb85a68cecddba57f
+        url: https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.1.1.tar.bz2
+
   - name: git-lfs
     buildsystem: simple
     build-commands:
@@ -37,6 +63,7 @@ modules:
         strip-components: 0
         url: https://github.com/git-lfs/git-lfs/releases/download/v2.12.0/git-lfs-linux-arm64-v2.12.0.tar.gz
         sha256: df6aa720ad53c2549035589fd0a62246ce06b1c3c8e65c35d7ce1ee43f7bc29d
+
   - name: sublime_merge
     buildsystem: simple
     build-commands:

--- a/com.sublimemerge.App.yaml
+++ b/com.sublimemerge.App.yaml
@@ -2,9 +2,9 @@
 app-id: com.sublimemerge.App
 command: sublime_merge
 
-runtime: org.freedesktop.Sdk
-runtime-version: '21.08'
-sdk: org.freedesktop.Sdk
+runtime: org.gnome.Sdk
+runtime-version: '41'
+sdk: org.gnome.Sdk
 
 separate-locales: false
 finish-args:

--- a/com.sublimemerge.App.yaml
+++ b/com.sublimemerge.App.yaml
@@ -15,7 +15,8 @@ finish-args:
   - --share=network
   - --filesystem=host  # uses the SDK's git binary directly, no portals
   - --filesystem=xdg-run/gnupg:ro  # for signing commits
-  - --own-name=com.sublimemerge  # app doesn't follow the app ID spec
+  - --talk-name=org.freedesktop.secrets # for access to the user's GPG keys for signing commits
+  - --own-name=com.sublimemerge # app doesn't follow the app ID spec
   - --device=dri
 
 modules:

--- a/com.sublimemerge.App.yaml
+++ b/com.sublimemerge.App.yaml
@@ -3,7 +3,7 @@ app-id: com.sublimemerge.App
 command: sublime_merge
 
 runtime: org.freedesktop.Sdk
-runtime-version: '20.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 
 separate-locales: false

--- a/com.sublimemerge.App.yaml
+++ b/com.sublimemerge.App.yaml
@@ -46,6 +46,11 @@ modules:
       - type: archive
         sha256: 10072045a3e043d0581f91cd5676fcac7ffee957a16636adedaa4f583a616470
         url: https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-1.2.0.tar.bz2
+        x-checker-data:
+            type: anitya
+            project-id: 3643
+            stable-only: true
+            url-template: https://www.gnupg.org/ftp/gcrypt/pinentry/pinentry-$version.tar.bz2
 
   - name: git-lfs
     buildsystem: simple


### PR DESCRIPTION
This commit fixes user's whose GPG keys are passphrase protected.
This is needed when the GPG key's passphrase is stored in GNOME Keyring.
Access to the SecretService allows the key to be unlocked when accessed.

Fixes #18