### PR TITLE
Add llvm13 extension

### DIFF
--- a/com.sublimemerge.App.yaml
+++ b/com.sublimemerge.App.yaml
@@ -5,6 +5,12 @@ runtime: org.freedesktop.Sdk
 runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 
+add-extensions:
+  org.freedesktop.Sdk.Extension.llvm13:
+    directory: clang
+    version: '21.08'
+    no-autodownload: false
+
 separate-locales: false
 finish-args:
   - --share=ipc
@@ -16,6 +22,8 @@ finish-args:
   - --filesystem=xdg-run/gnupg:ro  # for signing commits
   - --own-name=com.sublimemerge  # app doesn't follow the app ID spec
   - --device=dri
+  - --env=CLANG_FORMAT=python3 /app/clang/bin/clang-format
+  - --env=CLANG_FORMAT_DIFF=python3 /app/clang/share/clang/clang-format-diff.py
 
 modules:
   - name: git-lfs
@@ -102,6 +110,9 @@ modules:
         path: com.sublimemerge.App.desktop
       - type: file
         path: com.sublimemerge.App.png
+      - type: shell
+        commands:
+          - mkdir -p /app/clang
     modules:
       - name: ImageMagick
         config-opts:


### PR DESCRIPTION
Some C++ projects use clang-format in a pre-commit hook. The freedesktop
SDK used to contain clang and clang-format, but now it lives in an
extension. This change mounts the extension in the app, and sets up the
environment variables so that scripts can override the path for
clang-format and clang-format-diff.

Closes: #32