### PR TITLE
Add LLVM extension

### DIFF
--- a/com.sublimemerge.App.yaml
+++ b/com.sublimemerge.App.yaml
@@ -5,6 +5,12 @@ runtime: org.freedesktop.Sdk
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 
+add-extensions:
+  org.freedesktop.Sdk.Extension.llvm17:
+    directory: llvm
+    version: '23.08'
+    no-autodownload: true
+
 separate-locales: false
 finish-args:
   - --share=ipc
@@ -16,6 +22,7 @@ finish-args:
   - --filesystem=xdg-run/gnupg:ro  # for signing commits
   - --own-name=com.sublimemerge  # app doesn't follow the app ID spec
   - --device=dri
+  - --env=PATH=/usr/bin:/app/bin:/app/llvm/bin
 
 modules:
   - name: git-lfs
@@ -121,6 +128,9 @@ modules:
         path: com.sublimemerge.App.desktop
       - type: file
         path: com.sublimemerge.App.png
+      - type: shell
+        commands:
+          - mkdir -p /app/llvm
     modules:
       - name: ImageMagick
         config-opts:

--- a/com.sublimemerge.App.yaml
+++ b/com.sublimemerge.App.yaml
@@ -2,13 +2,13 @@ app-id: com.sublimemerge.App
 command: sublime_merge
 
 runtime: org.freedesktop.Sdk
-runtime-version: '23.08'
+runtime-version: "23.08"
 sdk: org.freedesktop.Sdk
 
 add-extensions:
   org.freedesktop.Sdk.Extension.llvm17:
     directory: llvm
-    version: '23.08'
+    version: "23.08"
     no-autodownload: true
 
 separate-locales: false
@@ -16,11 +16,11 @@ finish-args:
   - --share=ipc
   - --socket=x11
   - --socket=wayland
-  - --socket=ssh-auth  # for pushing to git remotes over SSH
+  - --socket=ssh-auth # for pushing to git remotes over SSH
   - --share=network
-  - --filesystem=host  # uses the SDK's git binary directly, no portals
-  - --filesystem=xdg-run/gnupg:ro  # for signing commits
-  - --own-name=com.sublimemerge  # app doesn't follow the app ID spec
+  - --filesystem=host # uses the SDK's git binary directly, no portals
+  - --filesystem=xdg-run/gnupg:ro # for signing commits
+  - --own-name=com.sublimemerge # app doesn't follow the app ID spec
   - --device=dri
   - --env=PATH=/usr/bin:/app/bin:/app/llvm/bin
 
@@ -38,7 +38,8 @@ modules:
         x-checker-data:
           type: json
           url: https://api.github.com/repos/git-lfs/git-lfs/releases/latest
-          url-query: .assets[] | select(.name=="git-lfs-linux-amd64-" + $version +
+          url-query:
+            .assets[] | select(.name=="git-lfs-linux-amd64-" + $version +
             ".tar.gz") | .browser_download_url
           version-query: .tag_name
       - type: archive
@@ -49,7 +50,8 @@ modules:
         x-checker-data:
           type: json
           url: https://api.github.com/repos/git-lfs/git-lfs/releases/latest
-          url-query: .assets[] | select(.name=="git-lfs-linux-arm64-" + $version +
+          url-query:
+            .assets[] | select(.name=="git-lfs-linux-arm64-" + $version +
             ".tar.gz") | .browser_download_url
           version-query: .tag_name
   # Dependency for git-flow
@@ -143,4 +145,4 @@ modules:
             url: https://github.com/ImageMagick/ImageMagick/archive/7.1.1-20.tar.gz
             sha256: 8e2a0b5feaa6a8004b7d611e46984eb2217eeaff8347c5642e6ce84ecaf16446
         cleanup:
-          - '*'
+          - "*"

--- a/com.sublimemerge.App.yaml
+++ b/com.sublimemerge.App.yaml
@@ -23,6 +23,7 @@ finish-args:
   - --own-name=com.sublimemerge # app doesn't follow the app ID spec
   - --device=dri
   - --env=PATH=/usr/bin:/app/bin:/app/llvm/bin
+  - --env=CLANG_FORMAT_DIFF=python3 /app/llvm/share/clang/clang-format-diff.py
 
 modules:
   - name: git-lfs


### PR DESCRIPTION
Add the LLVM extension to make clang tools available. Since not everyone need this, I've made it optional. Install the LLVM extension with: `flatpak install flathub org.freedesktop.Sdk.Extension.llvm17`

Fixes #32, supersedes #33. 