### PR TITLE
Update llvm extension to llvm20

### DIFF
--- a/com.sublimemerge.App.yaml
+++ b/com.sublimemerge.App.yaml
@@ -6,7 +6,7 @@ runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 
 add-extensions:
-  org.freedesktop.Sdk.Extension.llvm17:
+  org.freedesktop.Sdk.Extension.llvm20:
     directory: llvm
     version: '24.08'
     no-autodownload: true


### PR DESCRIPTION
llvm17//23.08 doesn't exist, so we need a newer version that is compatible with the 24.08 runtime.